### PR TITLE
add pages Artworks and ArtworkDetail

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,8 @@
 - Docker
 - Material UI
 - Vercel (proyecto desplegado)
+- react router dom (para manejo de rutas)
+- react query (para realizar peticiones a la API y cacheo de informacion)
 
 ## Ejecucion local
 
@@ -21,3 +23,7 @@
 ## Despliegue en Vercel
 
 - Si desea ver el proyecto desplegado en vercel puede hacerlo haciendo click [aquí](https://art-gallery-challenge.vercel.app/)
+
+## Diseño de baja fidelidad en Figma
+
+- Si desea ver el diseño prototipo del proyecto en baja fidelidad haga click [aquí](https://www.figma.com/design/FAKak2U4HLi9TTB9xcKGOG/Art-gallery?node-id=0-1&t=ayiNIVZ5cbSd0crM-1)

--- a/src/app/components/Nav/Nav.tsx
+++ b/src/app/components/Nav/Nav.tsx
@@ -37,23 +37,6 @@ export function ResponsiveNav() {
     <AppBar position="static">
       <Container maxWidth="xl">
         <Toolbar disableGutters>
-          <Typography
-            variant="h6"
-            noWrap
-            component={RouterLink}
-            to="/"
-            sx={{
-              display: { xs: "none", md: "flex" },
-              fontFamily: "monospace",
-              fontWeight: 700,
-              letterSpacing: ".3rem",
-              color: "inherit",
-              textDecoration: "none",
-            }}
-          >
-            Art Gallery
-          </Typography>
-
           <Box sx={{ flexGrow: 1, display: { xs: "flex", md: "none" } }}>
             <IconButton
               size="large"
@@ -118,8 +101,26 @@ export function ResponsiveNav() {
           >
             Art Gallery
           </Typography>
+          <Typography
+            variant="h6"
+            noWrap
+            component={RouterLink}
+            to="/"
+            sx={{
+              display: { xs: "none", md: "flex" },
+              fontFamily: "monospace",
+              fontWeight: 700,
+              letterSpacing: ".3rem",
+              color: "inherit",
+              textDecoration: "none",
+            }}
+          >
+            Art Gallery
+          </Typography>
+
           <Box
             sx={{
+              mr: 12,
               flexGrow: 1,
               display: { xs: "none", md: "flex" },
               justifyContent: "center",

--- a/src/app/components/ui/Gallery/Gallery.tsx
+++ b/src/app/components/ui/Gallery/Gallery.tsx
@@ -1,0 +1,135 @@
+import ImageList from "@mui/material/ImageList";
+import ImageListItem from "@mui/material/ImageListItem";
+import ImageListItemBar from "@mui/material/ImageListItemBar";
+import { Box, Link } from "@mui/material";
+import { Link as RouterLink } from "react-router-dom";
+import { ArtworkDeatailArrayType } from "../../../interfaces/interfaces";
+
+type GalleryProps = {
+  images: ArtworkDeatailArrayType;
+  configImages: string;
+  columns: number;
+  columnsMd: number;
+  gap: number;
+  gapMd: number;
+  height: number;
+  heightMd: number;
+};
+
+export function Gallery({
+  images,
+  configImages,
+  columns,
+  gap,
+  height,
+  columnsMd,
+  gapMd,
+  heightMd,
+}: GalleryProps) {
+  return (
+    <>
+      <Box
+        sx={{
+          display: { xs: "block", md: "none" },
+          height: { height },
+          overflow: "auto",
+        }}
+      >
+        <ImageList
+          sx={{
+            width: {
+              xs: 300,
+              sm: 560,
+              md: 800,
+              lg: 1100,
+              xl: "100%",
+            },
+            height: { height },
+            overflow: "auto",
+          }}
+          cols={columns}
+          gap={gap}
+        >
+          {images.map((item) => (
+            <ImageListItem key={item.id}>
+              <img
+                style={{
+                  objectFit: "scale-down",
+                }}
+                srcSet={`${configImages}/${item.image_id}/full/200,/0/default.jpg 200w, ${configImages}/${item.image_id}/full/400,/0/default.jpg?w=248&fit=crop&auto=format&dpr=2 2x 400w, ${configImages}/${item.image_id}/full/843,/0/default.jpg?w=248&fit=crop&auto=format&dpr=2 2x 843w`}
+                src={`${item.thumbnail.lqip}?w=248&fit=crop&auto=format&dpr=2 2x`}
+                sizes="(min-width: 1640px) 843px, (min-width: 1200px) 843px, (min-width: 900px) 843px, (min-width: 600px) 90.63vw,  90.63vw"
+                alt={item.title}
+                loading="lazy"
+              />
+              <ImageListItemBar
+                title={item.title}
+                subtitle={<span>by: {item.artist_title}</span>}
+                position="below"
+              />
+              <Link
+                to={`/artworks/${item.id}`}
+                component={RouterLink}
+                unstable_viewTransition
+                color="inherit"
+              >
+                More details
+              </Link>
+            </ImageListItem>
+          ))}
+        </ImageList>
+      </Box>
+      <Box
+        sx={{
+          display: { xs: "none", md: "block" },
+          height: { heightMd },
+          overflow: "auto",
+        }}
+      >
+        <ImageList
+          sx={{
+            width: {
+              xs: 300,
+              sm: 560,
+              md: 800,
+              lg: 1100,
+              xl: "100%",
+            },
+            height: { heightMd },
+            overflow: "auto",
+          }}
+          cols={columnsMd}
+          gap={gapMd}
+        >
+          {images.map((item) => (
+            <ImageListItem key={item.id}>
+              <img
+                style={{
+                  objectFit: "scale-down",
+                }}
+                srcSet={`${configImages}/${item.image_id}/full/200,/0/default.jpg 200w, ${configImages}/${item.image_id}/full/400,/0/default.jpg, ${configImages}/${item.image_id}/full/843,/0/default.jpg`}
+                src={`${item.thumbnail.lqip}`}
+                sizes="(min-width: 1640px) 843px, (min-width: 1200px) 843px, (min-width: 900px) 843px, (min-width: 600px) 90.63vw,  90.63vw"
+                alt={item.thumbnail.alt_text}
+                loading="lazy"
+              />
+              <ImageListItemBar
+                title={item.title}
+                subtitle={<span>by: {item.artist_title}</span>}
+                position="below"
+              />
+              <Link
+                to={`/artworks/${item.id}`}
+                component={RouterLink}
+                unstable_viewTransition
+                color="inherit"
+              >
+                More details
+              </Link>
+            </ImageListItem>
+          ))}
+        </ImageList>
+      </Box>
+    </>
+  );
+}

--- a/src/app/components/ui/Table/ArtworksTable.tsx
+++ b/src/app/components/ui/Table/ArtworksTable.tsx
@@ -1,0 +1,88 @@
+import Table from "@mui/material/Table";
+import TableBody from "@mui/material/TableBody";
+import TableCell from "@mui/material/TableCell";
+import TableContainer from "@mui/material/TableContainer";
+import TableHead from "@mui/material/TableHead";
+import TableRow from "@mui/material/TableRow";
+import Paper from "@mui/material/Paper";
+import { Link } from "@mui/material";
+import { Link as RouterLink } from "react-router-dom";
+import { ArtworkDeatailArrayType } from "../../../interfaces/interfaces";
+
+type ArtworksTableProps = {
+  artworks: ArtworkDeatailArrayType;
+};
+
+export function ArtworksTable({ artworks }: ArtworksTableProps) {
+  return (
+    <TableContainer component={Paper}>
+      <Table sx={{ minWidth: 300 }} aria-label="simple table">
+        <TableHead>
+          <TableRow>
+            <TableCell>Title</TableCell>
+            <TableCell>Short description</TableCell>
+            <TableCell>Artist</TableCell>
+            <TableCell>Place of origin</TableCell>
+            <TableCell>ID</TableCell>
+            <TableCell>More details</TableCell>
+          </TableRow>
+        </TableHead>
+        <TableBody>
+          {artworks.length === 0 && (
+            <TableRow>
+              <TableCell>No results</TableCell>
+            </TableRow>
+          )}
+          {artworks.map((artwork) => (
+            <TableRow key={artwork.id} sx={{}}>
+              <TableCell component="th" scope="row">
+                {artwork.title ? artwork.title : "No title"}
+              </TableCell>
+              <TableCell component="th" scope="row">
+                {artwork.short_description ? (
+                  <p
+                    dangerouslySetInnerHTML={{
+                      __html: artwork.short_description,
+                    }}
+                  ></p>
+                ) : (
+                  "No description"
+                )}
+              </TableCell>
+              <TableCell>
+                {artwork.artist_title ? (
+                  <Link
+                    to={`/agents/${artwork.artist_id}`}
+                    component={RouterLink}
+                    unstable_viewTransition
+                    color="inherit"
+                  >
+                    {artwork.artist_title}
+                  </Link>
+                ) : (
+                  "No artist name"
+                )}
+              </TableCell>
+              <TableCell>
+                {artwork.place_of_origin
+                  ? artwork.place_of_origin
+                  : "no place specified"}
+              </TableCell>
+              <TableCell>{artwork.id}</TableCell>
+              <TableCell>
+                <Link
+                  to={`/artworks/${artwork.id}`}
+                  component={RouterLink}
+                  unstable_viewTransition
+                  color="inherit"
+                >
+                  More details
+                </Link>
+              </TableCell>
+            </TableRow>
+          ))}
+        </TableBody>
+      </Table>
+    </TableContainer>
+  );
+}

--- a/src/app/constants/queryConstants.ts
+++ b/src/app/constants/queryConstants.ts
@@ -1,0 +1,3 @@
+export const QUERY_KEY_ARTWORKS = "artworks";
+export const QUERY_KEY_ARTWORKS_FILTERED = "filteredArtworwks";
+export const QUERY_KEY_ARTWORK_DETAIL = "artworkDetail";

--- a/src/app/constants/urlsAPI.ts
+++ b/src/app/constants/urlsAPI.ts
@@ -1,0 +1,8 @@
+export const API_ARTWORKS = "https://api.artic.edu/api/v1/artworks";
+export const API_ARTWORKS_SEARCH =
+  "https://api.artic.edu/api/v1/artworks/search?";
+export const API_AGENTS = "https://api.artic.edu/api/v1/artworks";
+
+//filtro de datos para imagenes
+export const ARTWORK_FIELDS_FILTER =
+  "fields=id,title,thumbnail,date_display,artist_display,artist_title,artist_id,place_of_origin,artwork_type_title,image_id,short_description,description,publication_history,catalogue_display,medium_display,dimensions";

--- a/src/app/interfaces/interfaces.ts
+++ b/src/app/interfaces/interfaces.ts
@@ -6,3 +6,86 @@ export interface ColorModeContextType {
   darkMode: boolean;
   setDarkMode: React.Dispatch<React.SetStateAction<boolean>>;
 }
+
+export interface ArtworkResponseType {
+  data: ArtworkDeatailType;
+  info: {
+    license_text: string;
+    license_links: string[];
+    version: string;
+  };
+  config: {
+    iiif_url: string;
+    website_url: string;
+  };
+}
+
+export interface ArtworksSearchResponseType {
+  preference: null;
+  pagination: {
+    total: number;
+    limit: number;
+    offset: number;
+    total_pages: number;
+    current_page: number;
+  };
+  data: ArtworkDeatailArrayType;
+  info: {
+    license_text: string;
+    license_links: string[];
+    version: string;
+  };
+  config: {
+    iiif_url: string;
+    website_url: string;
+  };
+}
+
+export type ArtworkDeatailArrayType = {
+  id: number;
+  title: string; // e.g. "The Bath"
+  thumbnail: {
+    lqip: string;
+    width: number;
+    height: number;
+    alt_text: string;
+  };
+  date_display: string | null; // e.g. "1890–91"
+  artist_display: string | null; //  e.g. "Mary Cassatt (American, 1844-1926)\nprinted with Leroy (French, active 1876-1900)" Nombre del artista y su nacionalidad
+  artist_title: string | null; // e.g. "Pablo Picasso" nombre del artista
+  artist_id: number | null; // e.g. 1
+  place_of_origin: string | null; // e.g. "United States"
+  artwork_type_title: string | null; // e.g. "Painting" Tipo de obra
+  image_id: string;
+  short_description: string | null;
+  description: string | null;
+  publication_history: string | null; // e.g. Lista exaustiva de los lugares publicados
+  catalogue_display: string | null; // e.g. "Breeskin 1970, no. 1" Lista de lugares publicados
+  medium_display: string | null; // e.g. "Color drypoint, aquatint and softground etching from two plates, printed à la poupée, on ivory laid paper" Sustancias o materiales usados
+  dimensions: string | null; // e.g. "Image/plate: 32.1 × 24.7 cm (12 11/16 × 9 3/4 in.); Sheet: 43.6 × 30 cm (17 3/16 × 11 13/16 in.)" medidas
+}[];
+export interface ArtworkDeatailType {
+  id: number;
+  title: string; // e.g. "The Bath"
+  thumbnail: {
+    lqip: string;
+    width: number;
+    height: number;
+    alt_text: string;
+  };
+  date_display: string | null; // e.g. "1890–91"
+  artist_display: string | null; //  e.g. "Mary Cassatt (American, 1844-1926)\nprinted with Leroy (French, active 1876-1900)" Nombre del artista y su nacionalidad
+  artist_title: string | null; // e.g. "Pablo Picasso" nombre del artista
+  artist_id: number | null; // e.g. 1
+  place_of_origin: string | null; // e.g. "United States"
+  artwork_type_title: string | null; // e.g. "Painting" Tipo de obra
+  image_id: string;
+  short_description: string | null;
+  description: string | null;
+  publication_history: string | null; // e.g. Lista exaustiva de los lugares publicados
+  catalogue_display: string | null; // e.g. "Breeskin 1970, no. 1" Lista de lugares publicados
+  medium_display: string | null; // e.g. "Color drypoint, aquatint and softground etching from two plates, printed à la poupée, on ivory laid paper" Sustancias o materiales usados
+  dimensions: string | null; // e.g. "Image/plate: 32.1 × 24.7 cm (12 11/16 × 9 3/4 in.); Sheet: 43.6 × 30 cm (17 3/16 × 11 13/16 in.)" medidas
+}
+
+// id,title,thumbnail,date_display,artist_display,artist_title,artist_id,place_of_origin,artwork_type_title,image_id,short_description,description,publication_history,catalogue_display,medium_display,dimensions

--- a/src/app/screens/Agent/AgentDetail/AgentDetail.tsx
+++ b/src/app/screens/Agent/AgentDetail/AgentDetail.tsx
@@ -1,7 +1,10 @@
+import { useParams } from "react-router-dom";
+
 export function AgentDetail() {
+  const { id } = useParams();
   return (
     <div>
-      <h1>AgentDetail</h1>
+      <h1>AgentDetail:{id}</h1>
     </div>
   );
 }

--- a/src/app/screens/Agent/Agents.tsx
+++ b/src/app/screens/Agent/Agents.tsx
@@ -1,7 +1,10 @@
+import { Typography } from "@mui/material";
 export function Agents() {
   return (
     <div>
-      <h1>Agent</h1>
+      <Typography variant="h3" gutterBottom>
+        Agents
+      </Typography>
     </div>
   );
 }

--- a/src/app/screens/Artwork/ArtworkDetail/ArtworkDetail.tsx
+++ b/src/app/screens/Artwork/ArtworkDetail/ArtworkDetail.tsx
@@ -1,7 +1,183 @@
+import { useParams } from "react-router-dom";
+import { useQuery } from "@tanstack/react-query";
+import { QUERY_KEY_ARTWORK_DETAIL } from "../../../constants/queryConstants";
+import { API_ARTWORKS } from "../../../constants/urlsAPI";
+import { Box } from "@mui/material";
+import { Paper, Typography, Divider, Link } from "@mui/material";
+import { Link as RouterLink } from "react-router-dom";
+
 export function ArtworkDetail() {
+  const { id } = useParams();
+  async function fetchArtwork() {
+    const res = await fetch(`${API_ARTWORKS}/${id}`);
+    const json = await res.json();
+    if (json.error == "Not Found") {
+      throw new Error(json);
+    }
+    console.log(json);
+    return json;
+  }
+  const {
+    data: artwork,
+    status: artworStatus,
+    error: artworkError,
+  } = useQuery({
+    queryKey: [QUERY_KEY_ARTWORK_DETAIL, id],
+    queryFn: fetchArtwork,
+  });
   return (
-    <div>
-      <h1>ArtworkDetail</h1>
-    </div>
+    <Box
+      sx={{
+        p: 4,
+        display: "flex",
+        flexDirection: "column",
+        alignItems: "center",
+        justifyContent: "center",
+      }}
+    >
+      {artworkError && <h2>{artworkError.message}</h2>}
+      {artworStatus === "pending" && <h2>Loading...</h2>}
+      {artwork && (
+        <>
+          <Typography variant="h3" gutterBottom sx={{ alignSelf: "center" }}>
+            {artwork.data.title}
+          </Typography>
+          <Divider component="hr" sx={{ width: { xs: "90vw", md: "80vw" } }} />
+          <Divider component="br" />
+          <Paper variant="outlined">
+            <img
+              srcSet={`${artwork.config.iiif_url}/${artwork.data.image_id}/full/200,/0/default.jpg 200w, ${artwork.config.iiif_url}/${artwork.data.image_id}/full/400,/0/default.jpg 400w, ${artwork.config.iiif_url}/${artwork.data.image_id}/full/843,/0/default.jpg 843w`}
+              sizes="(min-width: 1640px) 843px, (min-width: 1200px) 400px, (min-width: 900px) 200px, (min-width: 600px) 90.63vw,  90.63vw"
+              alt={artwork.data.title}
+              src={artwork.data.thumbnail.lqip}
+            />
+          </Paper>
+          <Box
+            sx={{
+              alignSelf: "flex-start",
+              ml: { xs: 2, md: 6, lg: 8, xl: 12 },
+            }}
+          >
+            <Typography variant="h5" gutterBottom>
+              Description:
+            </Typography>
+
+            <Typography variant="body1" gutterBottom>
+              {artwork.data.description ? (
+                <p
+                  dangerouslySetInnerHTML={{
+                    __html: artwork.data.description,
+                  }}
+                ></p>
+              ) : artwork.data.short_description ? (
+                <p
+                  dangerouslySetInnerHTML={{
+                    __html: artwork.short_description,
+                  }}
+                ></p>
+              ) : (
+                "No description"
+              )}
+            </Typography>
+
+            <Typography variant="h5" gutterBottom>
+              Details:
+            </Typography>
+            <Typography variant="body1" gutterBottom>
+              {artwork.data.artist_display ? (
+                <Link
+                  to={`/agents/${artwork.data.artist_id}`}
+                  component={RouterLink}
+                  unstable_viewTransition
+                  color="inherit"
+                >
+                  <p
+                    style={{ whiteSpace: "pre" }}
+                    dangerouslySetInnerHTML={{
+                      __html: artwork.data.artist_display,
+                    }}
+                  ></p>
+                </Link>
+              ) : artwork.data.artist_title ? (
+                <Link
+                  to={`/agents/${artwork.data.artist_id}`}
+                  component={RouterLink}
+                  unstable_viewTransition
+                  color="inherit"
+                >
+                  <p
+                    dangerouslySetInnerHTML={{
+                      __html: artwork.artist_title,
+                    }}
+                  ></p>
+                </Link>
+              ) : (
+                "No artist name"
+              )}
+            </Typography>
+            <Typography variant="body1" gutterBottom>
+              {artwork.data.place_of_origin ? (
+                <p>Place of origin: {artwork.data.place_of_origin}</p>
+              ) : (
+                "Place of origin: No specified"
+              )}
+            </Typography>
+            <Typography variant="body1" gutterBottom>
+              {artwork.data.date_display ? (
+                <p>Date: {artwork.data.date_display}</p>
+              ) : (
+                "Date: No specified"
+              )}
+            </Typography>
+            <Typography variant="body1" gutterBottom>
+              {artwork.data.artwork_type_title ? (
+                <p>Type: {artwork.data.artwork_type_title}</p>
+              ) : (
+                "Type: No specified"
+              )}
+            </Typography>
+            <Typography variant="body1" gutterBottom>
+              {artwork.data.medium_display ? (
+                <p>Medium display: {artwork.data.medium_display}</p>
+              ) : (
+                "Medium display: No specified"
+              )}
+            </Typography>
+            <Typography variant="body1" gutterBottom>
+              {artwork.data.dimensions ? (
+                <p>Dimensions: {artwork.data.dimensions}</p>
+              ) : (
+                "Dimensions: No specified"
+              )}
+            </Typography>
+            <Typography variant="body1" gutterBottom>
+              {artwork.data.publication_history ? (
+                <>
+                  Publications:
+                  <p
+                    dangerouslySetInnerHTML={{
+                      __html: artwork.data.publication_history,
+                    }}
+                  ></p>
+                </>
+              ) : artwork.data.catalogue_display ? (
+                <>
+                  Publications:
+                  <p
+                    dangerouslySetInnerHTML={{
+                      __html: artwork.data.catalogue_display,
+                    }}
+                  >
+                    {artwork.data.catalogue_display}
+                  </p>
+                </>
+              ) : (
+                "Publications: No specified"
+              )}
+            </Typography>
+          </Box>
+        </>
+      )}
+    </Box>
   );
 }

--- a/src/app/screens/Artwork/Artworks.tsx
+++ b/src/app/screens/Artwork/Artworks.tsx
@@ -1,7 +1,125 @@
+import React, { useState } from "react";
+import { Typography } from "@mui/material";
+import { Box } from "@mui/material";
+import TextField from "@mui/material/TextField";
+import { useQuery } from "@tanstack/react-query";
+import { ArtworksTable } from "../../components/ui/Table/ArtworksTable";
+import Pagination from "@mui/material/Pagination";
+import Stack from "@mui/material/Stack";
+import {
+  API_ARTWORKS_SEARCH,
+  ARTWORK_FIELDS_FILTER,
+} from "../../constants/urlsAPI";
+import { QUERY_KEY_ARTWORKS_FILTERED } from "../../constants/queryConstants";
+
+//<dangerouslySetInnerHTML={{ __html: html }}/>
 export function Artworks() {
+  const [findArtwork, setFindArtwork] = useState<string>("");
+  const [page, setPage] = useState<number>(1);
+  const [urlQuery, setUrlQuery] = useState<string>(
+    `${API_ARTWORKS_SEARCH}q=${findArtwork}&page=${page}&${ARTWORK_FIELDS_FILTER}`
+  );
+  async function fetchFilteredArtwork() {
+    const res = await fetch(urlQuery);
+    const json = await res.json();
+    if (json.error == "Not Found") {
+      throw new Error(json);
+    }
+    console.log(json);
+    return json;
+  }
+
+  const handleSubmit = (e: React.FormEvent<HTMLFormElement>) => {
+    e.preventDefault();
+    let query = "";
+    if (findArtwork != "") {
+      setPage(1);
+      query = `${API_ARTWORKS_SEARCH}q=${findArtwork}&page=${"1"}&${ARTWORK_FIELDS_FILTER}`;
+    }
+    setUrlQuery(query);
+  };
+
+  const handleChange = (event: React.ChangeEvent<unknown>, value: number) => {
+    event.preventDefault();
+    setPage(value);
+    setUrlQuery(
+      `${API_ARTWORKS_SEARCH}q=${findArtwork}&page=${value}&${ARTWORK_FIELDS_FILTER}`
+    );
+  };
+
+  const {
+    data: filteredArtworks,
+    status: statusFiltered,
+    error: errorFiltered,
+  } = useQuery({
+    queryKey: [QUERY_KEY_ARTWORKS_FILTERED, urlQuery, page],
+    queryFn: fetchFilteredArtwork,
+  });
   return (
-    <div>
-      <h1>Artwork</h1>
-    </div>
+    <Box
+      sx={{
+        p: 4,
+        display: "flex",
+        flexDirection: "column",
+        alignItems: "center",
+        justifyContent: "center",
+      }}
+    >
+      <Box
+        sx={{
+          display: "flex",
+          alignSelf: "flex-start",
+          flexDirection: { xs: "column", md: "row" },
+          alignItems: "center",
+          gap: { xs: "none", md: 4 },
+          p: { xs: 2, md: 0 },
+        }}
+      >
+        <Typography
+          variant="h3"
+          gutterBottom
+          sx={{ alignSelf: "flex-start", ml: { md: 8, lg: 12, xl: 16 } }}
+        >
+          Artworks
+        </Typography>
+        <Box
+          component="form"
+          sx={{
+            "& > :not(style)": { my: 1, mx: { xs: 0, md: 1 }, width: "25ch" },
+          }}
+          noValidate
+          autoComplete="off"
+          onSubmit={handleSubmit}
+        >
+          <TextField
+            id="outlined-basic"
+            label="Find Artwork"
+            variant="outlined"
+            value={findArtwork}
+            onChange={(e) => setFindArtwork(e.target.value)}
+          />
+        </Box>
+        <Typography sx={{ alignSelf: { xs: "flex-start", md: "center" } }}>
+          Page: {page}
+        </Typography>
+      </Box>
+      <>
+        {errorFiltered && <h2>{errorFiltered.message}</h2>}
+        {statusFiltered === "pending" && <h2>Loading...</h2>}
+        {filteredArtworks && (
+          // Tabla
+          <>
+            <ArtworksTable artworks={filteredArtworks.data} />
+            <Stack spacing={4} sx={{ p: 4 }}>
+              <Pagination
+                count={filteredArtworks.pagination.total_pages}
+                page={page}
+                onChange={handleChange}
+              />
+            </Stack>
+          </>
+        )}
+      </>
+    </Box>
   );
 }

--- a/src/app/screens/Home/Home.tsx
+++ b/src/app/screens/Home/Home.tsx
@@ -1,7 +1,77 @@
+import { Typography } from "@mui/material";
+import { Gallery } from "../../components/ui/Gallery/Gallery";
+import { Box } from "@mui/material";
+import { useQuery } from "@tanstack/react-query";
+import { QUERY_KEY_ARTWORKS } from "../../constants/queryConstants";
+import { API_ARTWORKS, ARTWORK_FIELDS_FILTER } from "../../constants/urlsAPI";
+
 export function Home() {
+  async function fetchArtwork() {
+    const res = await fetch(`${API_ARTWORKS}?limit=4&${ARTWORK_FIELDS_FILTER}`);
+    const json = await res.json();
+    if (json.error == "Not Found") {
+      throw new Error(json);
+    }
+    console.log(json);
+    return json;
+  }
+  const {
+    data: artworks,
+    status: artworkStatus,
+    error: artworkError,
+  } = useQuery({
+    queryKey: [QUERY_KEY_ARTWORKS],
+    queryFn: fetchArtwork,
+  });
   return (
-    <div>
-      <h1>Home2</h1>
-    </div>
+    <Box
+      sx={{
+        p: 4,
+        display: "flex",
+        flexDirection: "column",
+        alignItems: "center",
+        justifyContent: "center",
+      }}
+    >
+      <Typography
+        variant="h3"
+        gutterBottom
+        sx={{ alignSelf: "flex-start", ml: { md: 8, lg: 12, xl: 16 } }}
+      >
+        Artworks
+      </Typography>
+      {artworkError && <h2>{artworkError.message}</h2>}
+      {artworkStatus === "pending" && <h2>Loading...</h2>}
+      {artworks && (
+        <Gallery
+          images={artworks.data}
+          configImages={artworks.config.iiif_url}
+          columns={1}
+          gap={6}
+          height={600}
+          columnsMd={4}
+          gapMd={16}
+          heightMd={300}
+        />
+      )}
+      <Typography
+        variant="h3"
+        gutterBottom
+        sx={{ alignSelf: "flex-start", ml: { md: 8, lg: 12, xl: 16 } }}
+      >
+        Agents
+      </Typography>
+      {console.log(artworks)}
+      {/* <Gallery
+        images={artworks.data}
+        configImages={artworks.config.iiif_url}
+        columns={2}
+        gap={6}
+        height={600}
+        columnsMd={5}
+        gapMd={16}
+        heightMd={300}
+      /> */}
+    </Box>
   );
 }

--- a/src/routes.tsx
+++ b/src/routes.tsx
@@ -12,11 +12,11 @@ export const routes = [
     element: MainLayout(),
     errorElement: ErrorPage(),
     children: [
-      { path: "/", element: Home() },
-      { path: "/artworks", element: Artworks() },
-      { path: "/artworks/:id", element: ArtworkDetail() },
+      { path: "/", element: <Home /> },
+      { path: "/artworks", element: <Artworks /> },
+      { path: "/artworks/:id", element: <ArtworkDetail /> },
       { path: "/agents", element: Agents() },
-      { path: "/agents/:id", element: AgentDetail() },
+      { path: "/agents/:id", element: <AgentDetail /> },
     ],
   },
 ];


### PR DESCRIPTION
Se agregaron las vistas de Artworks y ArtworkDetail.
Se agrego una galeria que muestra algunas obras de arte en el home

Artworks:

- Muestra una tabla con informacion de obras de arte
- Cuenta con un paginado que permite la navegacion y acceso a los datos de la API
- Permite acceder a la vista de ArtworkDetail mediante un enlace
- Permite acceder a la vista de AgentDetail mediante un enlace

ArtworkDetail:

- Muestra la obra de arte seleccionada como imagen
- Muestra informacion de la obra de arte: titulo, nombre del artista, fecha de creacion, lugar de origen, etc.
- Permite acceder a la vista de AgentDetail mediante un enlace (con los datos del autor)

Home:

- Se agregó una galeria que muestra cuatro obras de arte
- Permite acceder a la vista de ArtworkDetail mediante un enlace